### PR TITLE
Fixing handling of null payloads

### DIFF
--- a/mosquitto-foreign.scm
+++ b/mosquitto-foreign.scm
@@ -36,8 +36,7 @@
   (define-syntax define-mcb
     (er-macro-transformer
      (lambda (exp r c)
-       (let (
-             (name (cadr exp))
+       (let ((name (cadr exp))
              (args (cddr exp)))
          `(,(r 'define) ,(string->symbol (string-append "%" (string-translate name "_" "-")))
            (,(r 'foreign-lambda*) void ((mosquitto-ptr mosq_ptr)

--- a/mosquitto.scm
+++ b/mosquitto.scm
@@ -11,6 +11,13 @@
 		   mqtt-client-subscribe-callback
 		   mqtt-client-unsubscribe-callback
 		   mqtt-client-log-callback
+                   set-mqtt-client-connect-callback!
+                   set-mqtt-client-disconnect-callback!
+                   set-mqtt-client-publish-callback!
+                   set-mqtt-client-message-callback!
+                   set-mqtt-client-subscribe-callback!
+                   set-mqtt-client-unsubscribe-callback!
+                   set-mqtt-client-log-callback!
 		   mqtt-message
 		   mqtt-message?
 		   mqtt-message-id
@@ -26,23 +33,7 @@
                    mqtt-publish
                    mqtt-subscribe
                    mqtt-unsubscribe
-                   mqtt-mosquitto-lib-version
-                   mqtt-client?
-                   mqtt-client-mosquitto
-                   mqtt-client-connect-callback
-                   mqtt-client-disconnect-callback
-                   mqtt-client-publish-callback
-                   mqtt-client-message-callback
-                   mqtt-client-subscribe-callback
-                   mqtt-client-unsubscribe-callback
-                   mqtt-client-log-callback
-                   set-mqtt-client-connect-callback!
-                   set-mqtt-client-disconnect-callback!
-                   set-mqtt-client-publish-callback!
-                   set-mqtt-client-message-callback!
-                   set-mqtt-client-subscribe-callback!
-                   set-mqtt-client-unsubscribe-callback!
-                   set-mqtt-client-log-callback!)
+                   mqtt-mosquitto-lib-version)
   (import scheme
           (chicken base)
           (chicken foreign)

--- a/mosquitto.scm
+++ b/mosquitto.scm
@@ -211,8 +211,10 @@
 
   (define (message-ptr->mqtt-message msg-ptr)
     (let* ((payload-len (%mosquitto-message-payloadlen msg-ptr))
-           (payload-blob (make-blob payload-len)))
-      (move-memory! (%mosquitto-message-payload msg-ptr) payload-blob payload-len)
+           (payload-blob (void)))
+      (unless (zero? payload-len)
+	(set! payload-blob (make-blob payload-len))
+	(move-memory! (%mosquitto-message-payload msg-ptr) payload-blob payload-len))
       (make-mqtt-message (%mosquitto-message-mid msg-ptr)
                          (%mosquitto-message-topic msg-ptr)
                          payload-blob

--- a/mosquitto.scm
+++ b/mosquitto.scm
@@ -1,16 +1,16 @@
 (include "mosquitto-foreign.scm")
 (module mosquitto (make-mqtt-client
-		   mqtt-client
-		   mqtt-client?
-		   mqtt-client-mosquitto
-		   mqtt-client-user-data
-		   mqtt-client-connect-callback
-		   mqtt-client-disconnect-callback
-		   mqtt-client-publish-callback
-		   mqtt-client-message-callback
-		   mqtt-client-subscribe-callback
-		   mqtt-client-unsubscribe-callback
-		   mqtt-client-log-callback
+                   mqtt-client
+                   mqtt-client?
+                   mqtt-client-mosquitto
+                   mqtt-client-user-data
+                   mqtt-client-connect-callback
+                   mqtt-client-disconnect-callback
+                   mqtt-client-publish-callback
+                   mqtt-client-message-callback
+                   mqtt-client-subscribe-callback
+                   mqtt-client-unsubscribe-callback
+                   mqtt-client-log-callback
                    set-mqtt-client-connect-callback!
                    set-mqtt-client-disconnect-callback!
                    set-mqtt-client-publish-callback!
@@ -18,13 +18,13 @@
                    set-mqtt-client-subscribe-callback!
                    set-mqtt-client-unsubscribe-callback!
                    set-mqtt-client-log-callback!
-		   mqtt-message
-		   mqtt-message?
-		   mqtt-message-id
-		   mqtt-message-topic
-		   mqtt-message-payload
-		   mqtt-message-qos
-		   mqtt-message-retain
+                   mqtt-message
+                   mqtt-message?
+                   mqtt-message-id
+                   mqtt-message-topic
+                   mqtt-message-payload
+                   mqtt-message-qos
+                   mqtt-message-retain
                    mqtt-connect
                    mqtt-reinitialise
                    mqtt-disconnect
@@ -81,7 +81,7 @@
   ;; EXTERNAL CALLBACKS
 
   (define-external (connect_cb (mosquitto-ptr mosq)
-			                         (c-pointer user-data)
+                               (c-pointer user-data)
                                (int rc))
     void
     (let* ((client (mosquitto-ptr-mqtt-client mosq))
@@ -91,7 +91,7 @@
 
 
   (define-external (disconnect_cb (mosquitto-ptr mosq)
-			                            (c-pointer user-data)
+                                  (c-pointer user-data)
                                   (int rc))
     void
     (let* ((client (mosquitto-ptr-mqtt-client mosq))
@@ -101,7 +101,7 @@
 
 
   (define-external (publish_cb (mosquitto-ptr mosq)
-			                         (c-pointer user-data)
+                               (c-pointer user-data)
                                (int mid))
     void
     (let* ((client (mosquitto-ptr-mqtt-client mosq))
@@ -111,7 +111,7 @@
 
 
   (define-external (message_cb (mosquitto-ptr mosq)
-			                         (c-pointer user-data)
+                               (c-pointer user-data)
                                ((const message-ptr) msg))
     void
     (let* ((client (mosquitto-ptr-mqtt-client mosq))
@@ -121,7 +121,7 @@
 
 
   (define-external (subscribe_cb (mosquitto-ptr mosq)
-			                           (c-pointer user-data)
+                                 (c-pointer user-data)
                                  (int mid)
                                  (int qos-count)
                                  ((c-pointer (const int)) granted-qos))
@@ -133,7 +133,7 @@
 
 
   (define-external (unsubscribe_cb (mosquitto-ptr mosq)
-			                             (c-pointer user-data)
+                                   (c-pointer user-data)
                                    (int mid))
     void
     (let* ((client (mosquitto-ptr-mqtt-client mosq))
@@ -143,7 +143,7 @@
 
 
   (define-external (log_cb (mosquitto-ptr mosq)
-			                     (c-pointer user-data)
+                           (c-pointer user-data)
                            (int level)
                            (c-string str))
     void
@@ -213,8 +213,8 @@
     (let* ((payload-len (%mosquitto-message-payloadlen msg-ptr))
            (payload-blob (void)))
       (unless (zero? payload-len)
-	(set! payload-blob (make-blob payload-len))
-	(move-memory! (%mosquitto-message-payload msg-ptr) payload-blob payload-len))
+        (set! payload-blob (make-blob payload-len))
+        (move-memory! (%mosquitto-message-payload msg-ptr) payload-blob payload-len))
       (make-mqtt-message (%mosquitto-message-mid msg-ptr)
                          (%mosquitto-message-topic msg-ptr)
                          payload-blob


### PR DESCRIPTION
Client could cause a runtime error by sending a message with null payload:

> running example from readme modified to connect with unix socket

```console
$ csi example.scm                                                                                            
CHICKEN
(c) 2008-2021, The CHICKEN Team
(c) 2000-2007, Felix L. Winkelmann
Version 5.3.0 (rev e31bbee5)
linux-unix-gnu-x86-64 [ 64bit dload ptables ]

Type ,? for help.
; loading example.scm ...
; loading /nix/store/pk3xa2milqiv3fp5v22srfbx8hqidwb5-chicken-5.3.0/lib/chicken/11/chicken.blob.import.so ...
; loading /nix/store/pk3xa2milqiv3fp5v22srfbx8hqidwb5-chicken-5.3.0/lib/chicken/11/chicken.string.import.so ...
; loading /nix/store/i0m9f0ppgq62rxihvd7z6m6im17ybsbv-chicken-mosquitto-0.1.4/lib/chicken/11/mosquitto.import.so ...
; loading /nix/store/i0m9f0ppgq62rxihvd7z6m6im17ybsbv-chicken-mosquitto-0.1.4/lib/chicken/11/mosquitto.so ...
; loading /nix/store/bxxf61yi5nnj4qsvvfb5qkkjvzs44xng-chicken-srfi-1-0.5.1/lib/chicken/11/srfi-1.so ...
Yay, we are connected!
```

send message with null payload:

```console
$ mosquitto_pub --unix ./test/mosquitto.sock -t topic1 -m ''
```

example crashed:

```console
Error: (move-memory!) bad argument type - not a block object: #f

	Call history:

	<syntax>	 (message (string-append "Topic: " (mqtt-message-topic msg) " " "Payload:" (blob->string (mqtt-messag...
	<syntax>	 (string-append "Topic: " (mqtt-message-topic msg) " " "Payload:" (blob->string (mqtt-message-payload...
	<syntax>	 (mqtt-message-topic msg)
	<syntax>	 (blob->string (mqtt-message-payload msg))
	<syntax>	 (mqtt-message-payload msg)
	<syntax>	 (mqtt-publish client "topic2" "message received, thanks!")
	<eval>	 (set-mqtt-client-message-callback! client (lambda (cl msg) (message (string-append "Topic: " (mqtt-m...
	<syntax>	 (mqtt-connect client "./test/mosquitto.sock" #:port 0)
	<eval>	 (mqtt-connect client "./test/mosquitto.sock" #:port 0)
	<syntax>	 (mqtt-loop-forever client)
	<eval>	 (mqtt-loop-forever client)
	<eval>	 (message "Yay, we are connected!")
	<eval>	 [message] (display message)
	<eval>	 [message] (newline)
	<eval>	 [message] (flush-output)
	<eval>	 (mqtt-subscribe client "topic1")	<--
```

Also, I have added some duplicate exports during #1, so fixing this too, sorry :)